### PR TITLE
Fix cleaning up old resharper downloads

### DIFF
--- a/make_virtualbox_image.sh
+++ b/make_virtualbox_image.sh
@@ -51,7 +51,7 @@ fi
 
 git co answer_files/2012_r2/
 echo "Cleaning up Resharper artifacts..."
-rm iso/other/ReSharper.exe
+rm -f iso/other/ReSharper.exe
 mkdir -p iso/other
 echo "Downloading Resharper..."
 [ -f iso/other/ReSharper.exe ] || curl -L -o "iso/other/ReSharper.exe" -C - "https://download.jetbrains.com/resharper/JetBrains.ReSharperUltimate.2015.1.1.exe"


### PR DESCRIPTION
It appears that you have misconfigured your script such that it does not
correctly detect whether a resharper.exe file is present or not present.
I have updated the source code of your program with a new algorithm that
will successfully continue whether or not a ReSharper.exe file is found
at the given path. I have tested this patch on my OSX machine which is
running OSX 10.9.5 and inside a Bash shell running on my machine.

Thank you,
Ben Moss
